### PR TITLE
Wallet ser test

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -3,5 +3,5 @@
   "state_entity_endpoint": "https://beta.mercurywallet.io",
   "swap_conductor_endpoint": "https://beta.mercurywallet.io",
   "network": "testnet",
-  "testing_mode": false
+  "testing_mode": true
 }

--- a/src/settings.json
+++ b/src/settings.json
@@ -3,5 +3,5 @@
   "state_entity_endpoint": "https://beta.mercurywallet.io",
   "swap_conductor_endpoint": "https://beta.mercurywallet.io",
   "network": "testnet",
-  "testing_mode": true
+  "testing_mode": false
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -53,7 +53,7 @@ export class Storage {
     // encrypt mnemonic
     wallet_json.mnemonic = encryptAES(wallet_json.mnemonic, wallet_json.password);
     // remove password and root keys
-    delete wallet_json.password;
+    wallet_json.password = ""
     wallet_json.account = this.accountToAddrMap(wallet_json.account);
     // remove testing_mode config
     delete wallet_json.config.testing_mode;


### PR DESCRIPTION
Correct password field deletion error in storage to enable unit test pass for wallet save/load - password field set to empty string instead of being deleted.